### PR TITLE
Fix FFmpeg ./configure warnings by installing coreutils.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ ARG MAKEFLAGS="-j4"
 # FFmpeg build dependencies.
 RUN apk add --update \
   build-base \
+  coreutils \
   freetype-dev \
   lame-dev \
   libogg-dev \


### PR DESCRIPTION
#23 