### PR TITLE
fix: envsubst must not subst nginx vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -161,6 +161,6 @@ ADD static /www/static
 EXPOSE 1935
 EXPOSE 80
 
-CMD /bin/sh -c "envsubst" < /etc/nginx/nginx.conf.template > \
+CMD /bin/sh -c "envsubst '\$HTTP_PORT\$RTMP_PORT'" < /etc/nginx/nginx.conf.template > \
   /etc/nginx/nginx.conf && \
   nginx


### PR DESCRIPTION
fixes #54 