### PR TITLE
Stunnel addition and example push to FB Live.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,7 @@ services:
       - RTMP_PORT=1935
     volumes:
       - ./certs:/opt/certs
+    links:
+      - stunnel
+  stunnel:
+    build: stunnel 

--- a/nginx.conf
+++ b/nginx.conf
@@ -13,13 +13,17 @@ rtmp {
 
         application stream {
             live on;
+            record off;
+            allow publish all;
 
             exec ffmpeg -i rtmp://localhost:1935/stream/$name
               -c:a libfdk_aac -b:a 128k -c:v libx264 -b:v 2500k -f flv -g 30 -r 30 -s 1280x720 -preset superfast -profile:v baseline rtmp://localhost:1935/hls/$name_720p2628kbs
               -c:a libfdk_aac -b:a 128k -c:v libx264 -b:v 1000k -f flv -g 30 -r 30 -s 854x480 -preset superfast -profile:v baseline rtmp://localhost:1935/hls/$name_480p1128kbs
               -c:a libfdk_aac -b:a 128k -c:v libx264 -b:v 750k -f flv -g 30 -r 30 -s 640x360 -preset superfast -profile:v baseline rtmp://localhost:1935/hls/$name_360p878kbs
               -c:a libfdk_aac -b:a 128k -c:v libx264 -b:v 400k -f flv -g 30 -r 30 -s 426x240 -preset superfast -profile:v baseline rtmp://localhost:1935/hls/$name_240p528kbs
-              -c:a libfdk_aac -b:a 64k -c:v libx264 -b:v 200k -f flv -g 15 -r 15 -s 426x240 -preset superfast -profile:v baseline rtmp://localhost:1935/hls/$name_240p264kbs;
+              -c:a libfdk_aac -b:a 64k -c:v libx264 -b:v 200k -f flv -g 15 -r 15 -s 426x240 -preset superfast -profile:v baseline rtmp://localhost:1935/hls/$name_240p264kbs
+              # Push to facebook - please set your streamkey
+              -c:a libfdk_aac -b:a 128k -c:v libx264 -b:v 2500k -f flv -g 30 -r 30 -s 1280x720 -preset superfast -profile:v baseline rtmp://stunnel:19350/rtmp/streamkey;
         }
 
         application hls {

--- a/nginx.conf
+++ b/nginx.conf
@@ -21,9 +21,29 @@ rtmp {
               -c:a libfdk_aac -b:a 128k -c:v libx264 -b:v 1000k -f flv -g 30 -r 30 -s 854x480 -preset superfast -profile:v baseline rtmp://localhost:1935/hls/$name_480p1128kbs
               -c:a libfdk_aac -b:a 128k -c:v libx264 -b:v 750k -f flv -g 30 -r 30 -s 640x360 -preset superfast -profile:v baseline rtmp://localhost:1935/hls/$name_360p878kbs
               -c:a libfdk_aac -b:a 128k -c:v libx264 -b:v 400k -f flv -g 30 -r 30 -s 426x240 -preset superfast -profile:v baseline rtmp://localhost:1935/hls/$name_240p528kbs
-              -c:a libfdk_aac -b:a 64k -c:v libx264 -b:v 200k -f flv -g 15 -r 15 -s 426x240 -preset superfast -profile:v baseline rtmp://localhost:1935/hls/$name_240p264kbs
-              # Push to facebook - please set your streamkey
+              -c:a libfdk_aac -b:a 64k -c:v libx264 -b:v 200k -f flv -g 15 -r 15 -s 426x240 -preset superfast -profile:v baseline rtmp://localhost:1935/hls/$name_240p264kbs;
+
+            push rtmp://localhost:1935/facebook;
+            push rtmp://localhost:1935/youtube;
+        }
+
+        application facebook {
+            live on;
+            record off;
+            
+            # Transcode and push the stream to stunnel for FB Live RMTPS requirements
+            exec ffmpeg -i rtmp://localhost:1935/facebook/$name
               -c:a libfdk_aac -b:a 128k -c:v libx264 -b:v 2500k -f flv -g 30 -r 30 -s 1280x720 -preset superfast -profile:v baseline rtmp://stunnel:19350/rtmp/streamkey;
+        }
+
+        application youtube {
+            live on;
+            record off;
+            
+            exec ffmpeg -i rtmp://localhost:1935/youtube/$name
+              -c:a libfdk_aac -b:a 128k -c:v libx264 -b:v 2500k -f flv -g 30 -r 30 -s 1280x720 -preset superfast -profile:v baseline rtmp://a.rtmp.youtube.com/live2/streamkey;
+            # Alternatively, push without any transcoding
+            #push rtmp://a.rtmp.youtube.com/live2/streamkey;
         }
 
         application hls {

--- a/stunnel/Dockerfile
+++ b/stunnel/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.8
+RUN apk update		&& \
+	apk add			   \
+		openssl		   \
+		ca-certificates	   \
+		stunnel
+
+ADD stunnel.conf /etc/stunnel/stunnel.conf
+
+EXPOSE 19350
+
+CMD /usr/bin/stunnel

--- a/stunnel/run.sh
+++ b/stunnel/run.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+STUNNEL_CONFIG_FILE=/etc/stunnel/stunnel.conf
+
+STUNNEL_CONNECTIONS=${STUNNEL_CONNECTIONS-live-api-s.facebook.com:443:19350}
+STUNNEL_CONFIG_URLS=$(echo ${STUNNEL_CONNECTIONS} | sed "s/,/\n/g")
+
+apply_config() {
+
+	echo "Creating config"
+## Standard config:
+
+cat >${STUNNEL_CONFIG_FILE} <<!EOF
+pid = /run/stunnel.pid
+
+# Some performance tunings
+socket = l:TCP_NODELAY=1
+socket = r:TCP_NODELAY=1
+
+output = /var/log/stunnel.log
+foreground = yes
+
+# Service-level configuration
+!EOF
+
+## Tunnel configurations
+
+for CONFIG_URL in $(echo ${STUNNEL_CONFIG_URLS}); do
+	set -- $(echo ${CONFIG_URL} | sed "s/:/ /g")
+	echo "Creating tunnel for $1"
+	cat >>${STUNNEL_CONFIG_FILE} <<!EOF
+
+[${1}]
+client = yes
+accept = 0.0.0.0:${3}
+connect = ${1}:${2}
+!EOF
+done
+}
+
+if ! [ -f ${STUNNEL_CONFIG_FILE} ]; then
+	apply_config
+else
+	echo "CONFIG EXISTS - Not creating!"
+fi
+
+echo "Starting server..."
+/usr/bin/stunnel

--- a/stunnel/stunnel.conf
+++ b/stunnel/stunnel.conf
@@ -1,0 +1,16 @@
+pid = /run/stunnel.pid
+
+# Some performance tunings
+socket = l:TCP_NODELAY=1
+socket = r:TCP_NODELAY=1
+
+output = /var/log/stunnel.log
+foreground = yes
+
+# Service-level configuration
+[fb-live]
+client = yes
+accept = 0.0.0.0:19350
+connect = live-api-s.facebook.com:443
+verifyChain = no
+


### PR DESCRIPTION
Added Stunnel container which can push a RTMPS stream to FB Live for example. This may be able to help with #25.

So the real work was done by @jessicah which you can find [here](https://github.com/jessicah/nginx-rtmp-stunnel).

Now I'm not a master of Docker yet but I think the stunnel code could be built into the main image. I also do not fully understand if I am using the extra `exec ffmpeg ...` stream correctly to push to FB Live or if that should be a separate `exec` command to keep it distinct from the HLS streams.

EDIT: I've seen another example somewhere of pushing the stream to other applications and handling their respective transcoding and settings there which seemed more clean than what I originally had. Also added example for pushing to Youtube.

A new question I have now is what could be done to dynamically set when I want to begin pushing to FB Live while keeping the HLS stream active all the time. Or if that is possible without something more complex.

