### PR TITLE
Use the HTTPS_PORT variable instead of 443.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -53,7 +53,8 @@ http {
 
         # Uncomment these lines to enable SSL.
         # Update the ssl paths with your own certificate and private key.
-        # listen 443 ssl;
+            
+        # listen ${HTTPS_PORT} ssl;
         # ssl_certificate     /opt/certs/example.com.crt;
         # ssl_certificate_key /opt/certs/example.com.key;
 


### PR DESCRIPTION
Given that an `HTTPS_PORT` environment variable is defined in the `Dockerfile` it's bettere to use it in the Nginx configuration so that if one redefines such variable in the environment it will be reflected in the server configuration.