### PR TITLE
Bump Nginx to 1.19.7, ffmpeg to 4.3.2 and alpine to 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-ARG NGINX_VERSION=1.18.0
+ARG NGINX_VERSION=1.19.7
 ARG NGINX_RTMP_VERSION=1.2.1
-ARG FFMPEG_VERSION=4.3.1
+ARG FFMPEG_VERSION=4.3.2
 
 
 ##############################
 # Build the NGINX-build image.
-FROM alpine:3.11 as build-nginx
+FROM alpine:3.13 as build-nginx
 ARG NGINX_VERSION
 ARG NGINX_RTMP_VERSION
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 A Dockerfile installing NGINX, nginx-rtmp-module and FFmpeg from source with
 default settings for HLS live streaming. Built on Alpine Linux.
 
-* Nginx 1.18.0 (Stable version compiled from source)
+* Nginx 1.19.7 (Mainline version compiled from source)
 * nginx-rtmp-module 1.2.1 (compiled from source)
-* ffmpeg 4.3.1 (compiled from source)
+* ffmpeg 4.3.2 (compiled from source)
 * Default HLS settings (See: [nginx.conf](nginx.conf))
 
 [![Docker Stars](https://img.shields.io/docker/stars/alfg/nginx-rtmp.svg)](https://hub.docker.com/r/alfg/nginx-rtmp/)


### PR DESCRIPTION
I switched nginx from stable to mainline because [here](https://www.nginx.com/blog/nginx-1-12-1-13-released/) they say

> We generally recommend using the mainline branch. This is where we commit all new features, performance improvements, and enhancements. We actively test and QA the mainline branch, so it’s arguably more stable than the “stable” branch.

 If that's undesirable lmk.