### PR TITLE
Hide server_tokens

### DIFF
--- a/nginx-cuda.conf
+++ b/nginx-cuda.conf
@@ -35,6 +35,7 @@ http {
     root /www/static;
     sendfile off;
     tcp_nopush on;
+    server_tokens off;
     access_log /dev/stdout combined;
 
     # Uncomment these lines to enable SSL.

--- a/nginx.conf
+++ b/nginx.conf
@@ -44,6 +44,7 @@ http {
     root /www/static;
     sendfile off;
     tcp_nopush on;
+    server_tokens off;
     access_log /dev/stdout combined;
 
     # Uncomment these lines to enable SSL.


### PR DESCRIPTION
It would be good to hide the Nginx server version to comply with security best practices.