### PR TITLE
Update default SSL config

### DIFF
--- a/nginx-cuda.conf
+++ b/nginx-cuda.conf
@@ -39,10 +39,11 @@ http {
     access_log /dev/stdout combined;
 
     # Uncomment these lines to enable SSL.
-    # ssl_ciphers         HIGH:!aNULL:!MD5;
-    # ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
-    # ssl_session_cache   shared:SSL:10m;
-    # ssl_session_timeout 10m;
+    # ssl_protocols TLSv1.2 TLSv1.3;
+    # ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    # ssl_prefer_server_ciphers off;
+    # ssl_session_cache shared:SSL:10m;
+    # ssl_session_timeout 1d;
 
     server {
         listen ${HTTP_PORT};

--- a/nginx.conf
+++ b/nginx.conf
@@ -48,10 +48,11 @@ http {
     access_log /dev/stdout combined;
 
     # Uncomment these lines to enable SSL.
-    # ssl_ciphers         HIGH:!aNULL:!MD5;
-    # ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
-    # ssl_session_cache   shared:SSL:10m;
-    # ssl_session_timeout 10m;
+    # ssl_protocols TLSv1.2 TLSv1.3;
+    # ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    # ssl_prefer_server_ciphers off;
+    # ssl_session_cache shared:SSL:10m;
+    # ssl_session_timeout 1d;
 
     server {
         listen ${HTTP_PORT};


### PR DESCRIPTION
- Disable insecure ciphers and protocols. 
- Bump ssl_session_timeout to recommended 1d

Based on Mozilla Guideline v5.6 (https://ssl-config.mozilla.org/)