### PR TITLE
Integrate a thumbnailer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -165,7 +165,7 @@ COPY --from=build-ffmpeg /usr/lib/libfdk-aac.so.2 /usr/lib/libfdk-aac.so.2
 # Add NGINX path, config and static files.
 ENV PATH "${PATH}:/usr/local/nginx/sbin"
 COPY nginx.conf /etc/nginx/nginx.conf.template
-RUN mkdir -p /opt/data && mkdir /www
+RUN mkdir -p /opt/data/thumb && mkdir /www
 COPY static /www/static
 
 EXPOSE 1935

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -177,7 +177,7 @@ COPY --from=build-ffmpeg /usr/lib/x86_64-linux-gnu/libfdk-aac.so.1 /usr/lib/x86_
 
 # Add NGINX path, config and static files.
 ENV PATH "${PATH}:/usr/local/nginx/sbin"
-RUN mkdir -p /opt/data && mkdir /www
+RUN mkdir -p /opt/data/thumb && mkdir /www
 COPY nginx-cuda.conf /etc/nginx/nginx.conf.template
 COPY entrypoint.cuda.sh /opt/entrypoint.sh
 RUN chmod gu+x /opt/entrypoint.sh

--- a/nginx-cuda.conf
+++ b/nginx-cuda.conf
@@ -75,6 +75,12 @@ http {
           add_header Access-Control-Allow-Origin *;
         }
 
+        location /thumb {
+          alias /opt/data/thumb;
+          add_header Cache-Control no-cache;
+          add_header Access-Control-Allow-Origin *;
+        }
+        
         location /stat {
             rtmp_stat all;
             rtmp_stat_stylesheet stat.xsl;

--- a/nginx.conf
+++ b/nginx.conf
@@ -21,8 +21,8 @@ rtmp {
               -c:a libfdk_aac -b:a 128k -c:v libx264 -b:v 400k -f flv -g 30 -r 30 -s 426x240 -preset superfast -profile:v baseline rtmp://localhost:1935/hls/$name_240p528kbs
               -c:a libfdk_aac -b:a 64k -c:v libx264 -b:v 200k -f flv -g 15 -r 15 -s 426x240 -preset superfast -profile:v baseline rtmp://localhost:1935/hls/$name_240p264kbs;
 			  
-            exec_publish ffmpeg -i rtmp://localhost:1935/stream/$name -y -q:v 5 -r 1 -update 1 /opt/data/thumb/$name_thumb.jpg;
-            exec_publish_done rm /opt/data/thumb/$name_thumb.jpg;
+            exec_publish ffmpeg -i rtmp://localhost:1935/stream/$name -y -q:v 5 -r 1 -update 1 /opt/data/thumb/$name.jpg;
+            exec_publish_done rm /opt/data/thumb/$name.jpg;
         }
 
         application hls {

--- a/nginx.conf
+++ b/nginx.conf
@@ -20,6 +20,9 @@ rtmp {
               -c:a libfdk_aac -b:a 128k -c:v libx264 -b:v 750k -f flv -g 30 -r 30 -s 640x360 -preset superfast -profile:v baseline rtmp://localhost:1935/hls/$name_360p878kbs
               -c:a libfdk_aac -b:a 128k -c:v libx264 -b:v 400k -f flv -g 30 -r 30 -s 426x240 -preset superfast -profile:v baseline rtmp://localhost:1935/hls/$name_240p528kbs
               -c:a libfdk_aac -b:a 64k -c:v libx264 -b:v 200k -f flv -g 15 -r 15 -s 426x240 -preset superfast -profile:v baseline rtmp://localhost:1935/hls/$name_240p264kbs;
+			  
+            exec_publish ffmpeg -i rtmp://localhost:1935/stream/$name -y -q:v 5 -r 1 -update 1 /tmp/$name_thumb.jpg;
+            exec_publish_done rm /tmp/$name_thumb.jpg;
         }
 
         application hls {

--- a/nginx.conf
+++ b/nginx.conf
@@ -87,6 +87,12 @@ http {
           add_header Access-Control-Allow-Origin *;
         }
 
+        location /thumb {
+          alias /opt/data/thumb;
+          add_header Cache-Control no-cache;
+          add_header Access-Control-Allow-Origin *;
+        }
+
         location /stat {
             rtmp_stat all;
             rtmp_stat_stylesheet stat.xsl;

--- a/nginx.conf
+++ b/nginx.conf
@@ -21,8 +21,8 @@ rtmp {
               -c:a libfdk_aac -b:a 128k -c:v libx264 -b:v 400k -f flv -g 30 -r 30 -s 426x240 -preset superfast -profile:v baseline rtmp://localhost:1935/hls/$name_240p528kbs
               -c:a libfdk_aac -b:a 64k -c:v libx264 -b:v 200k -f flv -g 15 -r 15 -s 426x240 -preset superfast -profile:v baseline rtmp://localhost:1935/hls/$name_240p264kbs;
 			  
-            exec_publish ffmpeg -i rtmp://localhost:1935/stream/$name -y -q:v 5 -r 1 -update 1 /tmp/$name_thumb.jpg;
-            exec_publish_done rm /tmp/$name_thumb.jpg;
+            exec_publish ffmpeg -i rtmp://localhost:1935/stream/$name -y -q:v 5 -r 1 -update 1 /opt/data/thumb/$name_thumb.jpg;
+            exec_publish_done rm /opt/data/thumb/$name_thumb.jpg;
         }
 
         application hls {


### PR DESCRIPTION
This pull request attempts to integrate a thumbnailer for each stream. It's refreshed every second. 

The thumbnails are written to http://servername/thumb/$name.jpg. The thumbnails are removed when the stream disconnects. Nginx doesn't cache the thumbnails.